### PR TITLE
feat(editor): Track modifications and enable resetting all changes

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -11,7 +11,6 @@ use std::path::PathBuf;
 pub struct Editor {
     buffer: TextBuffer,
     current_file: Option<PathBuf>,
-    is_modified: bool,
     viewport_size: usize,
     scroll_offset: usize,
     status_message: String,
@@ -24,7 +23,6 @@ impl Editor {
             current_file: None,
             viewport_size: 0,
             scroll_offset: 0,
-            is_modified: false,
             status_message: "Rust Text Editor".to_string(),
         }
     }
@@ -35,7 +33,6 @@ impl Editor {
             current_file: None,
             scroll_offset: 0,
             viewport_size: 0,
-            is_modified: false,
             status_message: "Rust Text Editor".to_string(),
         }
     }
@@ -47,7 +44,6 @@ impl Editor {
             current_file: Some(path.clone()),
             scroll_offset: 0,
             viewport_size: 0,
-            is_modified: false,
             status_message: format!("Opened: {}", path.display()),
         })
     }
@@ -61,7 +57,7 @@ impl Editor {
             Some(path) => {
                 let content = self.buffer.get_content();
                 fs::write(path, content)?;
-                self.is_modified = false;
+                self.buffer.mark_buffer_as_saved();
                 self.status_message = format!("Saved: {}", path.display());
                 Ok(())
             }
@@ -73,7 +69,7 @@ impl Editor {
         self.current_file = Some(path.clone());
         let content = self.buffer.get_content();
         fs::write(&path, content)?;
-        self.is_modified = false;
+        self.buffer.mark_buffer_as_saved();
         self.status_message = format!("Saved: {}", path.display());
         Ok(())
     }
@@ -108,11 +104,6 @@ impl Editor {
         Ok(())
     }
 
-    fn mark_modified(&mut self) {
-        if !self.is_modified {
-            self.is_modified = true;
-        }
-    }
 
     fn render(&self) -> io::Result<()> {
 
@@ -183,11 +174,16 @@ impl Editor {
 
         match key_event.code {
             KeyCode::Char('q') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                if self.is_modified {
+                if self.is_modified() {
                     self.status_message = "File modified, press ctrl-q to quit without saving".to_string();
                     return Ok(false);
                 }
                 return Ok(true);
+            }
+            KeyCode::Char('r') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                if self.is_modified() {
+                    self.buffer.reset_buffer();
+                }
             }
             KeyCode::Char('s') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
                 match self.save_file() {
@@ -204,11 +200,9 @@ impl Editor {
             }
             KeyCode::Char(ch) => {
                 self.buffer.insert_char(ch);
-                self.mark_modified();
             }
             KeyCode::Backspace => {
                 self.buffer.delete_char();
-                self.mark_modified();
             }
             KeyCode::Left => {
                 self.buffer.move_cursor_left();
@@ -224,7 +218,6 @@ impl Editor {
             }
             KeyCode::Enter => {
                 self.buffer.insert_char('\n');
-                self.mark_modified();
             }
             _ => {}
         }
@@ -242,5 +235,9 @@ impl Editor {
         if cursor_row < self.scroll_offset {
             self.scroll_offset = cursor_row;
         }
+    }
+
+    fn is_modified(&self) -> bool {
+        self.buffer.is_modified()
     }
 }

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -1,25 +1,38 @@
 use std::cmp::min;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use ropey::Rope;
 
 pub struct TextBuffer {
     content: Rope,
+    original_content: Rope,
+    original_content_hash: u64,
     cursor_position: usize,
+    content_hash: u64,
 }
 
 impl TextBuffer {
     pub fn new() -> TextBuffer {
+        let content = Rope::new();
+        let content_hash = Self::hash_rope(&content);
         TextBuffer {
-            content: Rope::new(),
+            content: content.clone(),
+            original_content: content,
+            original_content_hash: content_hash,
             cursor_position: 0,
+            content_hash,
         }
     }
 
     pub fn from_string(string: String) -> TextBuffer {
         let content = Rope::from(string);
         let cursor_position = content.len_chars();
+        let content_hash = Self::hash_rope(&content);
         TextBuffer {
-            content,
+            content: content.clone(),
             cursor_position,
+            original_content: content,
+            original_content_hash: content_hash,
+            content_hash,
         }
     }
 
@@ -37,6 +50,7 @@ impl TextBuffer {
     pub fn insert_char(&mut self, ch: char) {
         self.content.insert_char(self.cursor_position, ch);
         self.cursor_position += 1;
+        self.update_content_hash();
     }
 
     pub fn delete_char(&mut self) {
@@ -44,6 +58,7 @@ impl TextBuffer {
             self.cursor_position -= 1;
             self.content
                 .remove(self.cursor_position..self.cursor_position + 1);
+            self.update_content_hash();
         }
     }
 
@@ -69,6 +84,10 @@ impl TextBuffer {
 
             self.cursor_position = prev_line_start + min(col_in_line, prev_line_len);
         }
+    }
+
+    fn update_content_hash(&mut self) {
+        self.content_hash = Self::hash_rope(&self.content);
     }
 
     pub fn move_cursor_down(&mut self) {
@@ -108,6 +127,29 @@ impl TextBuffer {
             "C:{} B:{} L:{} Ch:{} AvgChunk:{} Eff:{:.2}",
             chars, bytes, lines, chunks, avg_chunk_size, efficiency_ratio
         )
+    }
+
+    pub fn is_modified(&self) -> bool {
+        if self.content_hash != self.original_content_hash {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn mark_buffer_as_saved(&mut self) {
+        self.original_content = self.content.clone();
+        self.content_hash = Self::hash_rope(&self.content);
+        self.original_content_hash = Self::hash_rope(&self.original_content);
+    }
+
+    fn hash_rope(rope: &Rope) -> u64 {
+        // Iteratively hashes the chunks in a rope.
+        let mut hasher = DefaultHasher::new();
+        for chunk in rope.chunks() {
+            chunk.hash(&mut hasher);
+        }
+        hasher.finish()
     }
 }
 
@@ -264,5 +306,39 @@ mod tests {
 
         assert_eq!(buffer.get_content(), "hello");
         assert_eq!(buffer.get_cursor_position(), 2);
+    }
+
+    #[test]
+    fn test_modified_hash() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        buffer.insert_char(' ');
+        assert!(buffer.is_modified());
+        buffer.delete_char();
+        assert!(!buffer.is_modified());
+    }
+
+    #[test]
+    fn test_modified_hash_with_save() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        buffer.insert_char(' ');
+        assert!(buffer.is_modified());
+        buffer.mark_buffer_as_saved();
+        assert!(!buffer.is_modified());
+    }
+
+    #[test]
+    fn test_long_modified_hash() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        for char in 'a'..'z' {
+            buffer.insert_char(char);
+            assert!(buffer.is_modified());
+        }
+
+        for char in 'a'..'z' {
+            assert!(buffer.is_modified());
+            buffer.delete_char();
+        }
+
+        assert!(!buffer.is_modified());
     }
 }

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -151,6 +151,11 @@ impl TextBuffer {
         }
         hasher.finish()
     }
+
+    pub fn reset_buffer(&mut self) {
+        self.content = self.original_content.clone();
+        self.content_hash = Self::hash_rope(&self.content);
+    }
 }
 
 #[cfg(test)]
@@ -340,5 +345,19 @@ mod tests {
         }
 
         assert!(!buffer.is_modified());
+    }
+
+    #[test]
+    fn test_reset_buffer() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        for char in 'a'..'z' {
+            buffer.insert_char(char);
+            assert!(buffer.is_modified());
+        }
+
+        buffer.reset_buffer();
+        assert!(!buffer.is_modified());
+
+        assert_eq!(buffer.get_content(), "hello");
     }
 }

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -6,6 +6,7 @@ pub struct TextBuffer {
     content: Rope,
     original_content: Rope,
     original_content_hash: u64,
+    original_cursor_position: usize,
     cursor_position: usize,
     content_hash: u64,
 }
@@ -18,6 +19,7 @@ impl TextBuffer {
             content: content.clone(),
             original_content: content,
             original_content_hash: content_hash,
+            original_cursor_position: 0,
             cursor_position: 0,
             content_hash,
         }
@@ -30,6 +32,7 @@ impl TextBuffer {
         TextBuffer {
             content: content.clone(),
             cursor_position,
+            original_cursor_position: cursor_position,
             original_content: content,
             original_content_hash: content_hash,
             content_hash,
@@ -140,7 +143,8 @@ impl TextBuffer {
     pub fn mark_buffer_as_saved(&mut self) {
         self.original_content = self.content.clone();
         self.content_hash = Self::hash_rope(&self.content);
-        self.original_content_hash = Self::hash_rope(&self.original_content);
+        self.original_content_hash = Self::hash_rope(&self.content);
+        self.original_cursor_position = self.cursor_position;
     }
 
     fn hash_rope(rope: &Rope) -> u64 {
@@ -154,6 +158,7 @@ impl TextBuffer {
 
     pub fn reset_buffer(&mut self) {
         self.content = self.original_content.clone();
+        self.cursor_position = self.original_cursor_position;
         self.content_hash = Self::hash_rope(&self.content);
     }
 }
@@ -356,8 +361,8 @@ mod tests {
         }
 
         buffer.reset_buffer();
-        assert!(!buffer.is_modified());
 
+        assert!(!buffer.is_modified());
         assert_eq!(buffer.get_content(), "hello");
     }
 }


### PR DESCRIPTION
## Summary

  - Implemented modification tracking system using content hashing to detect changes in TextBuffer
  - Added reset functionality (Ctrl+R) to revert buffer to last saved state
  - Refactored Editor to use TextBuffer's modification tracking instead of maintaining separate state