### PR TITLE
feat(editor): Basic tree-sitter integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +22,15 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "cc"
+version = "1.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -87,6 +105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +119,28 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
@@ -129,6 +175,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mio"
@@ -193,6 +245,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "ropey"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,8 +287,11 @@ dependencies = [
 name = "rust-text-editor"
 version = "0.1.0"
 dependencies = [
+ "cc",
  "crossterm",
  "ropey",
+ "tree-sitter",
+ "tree-sitter-rust",
 ]
 
 [[package]]
@@ -224,10 +308,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -272,6 +401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +415,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cf18d43cbf0bfca51f657132cc616a5097edc4424d538bae6fa60142eaf9f0"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2024"
 [dependencies]
 crossterm = "0.29.0"
 ropey = "1.6.1"
+tree-sitter = "0.25.6"
+tree-sitter-rust = "0.24.0"
+
+[build-dependencies]
+cc = "1.2.27"

--- a/queries/rust.scm
+++ b/queries/rust.scm
@@ -1,0 +1,32 @@
+(line_comment) @comment
+(block_comment) @comment
+
+(string_literal) @string
+(raw_string_literal) @string
+(char_literal) @string
+
+(integer_literal) @number
+(float_literal) @number
+
+"fn" @keyword
+"let" @keyword
+"if" @keyword
+"else" @keyword
+"for" @keyword
+"while" @keyword
+"loop" @keyword
+"match" @keyword
+"return" @keyword
+
+; Function definitions
+(function_item
+  name: (identifier) @function)
+
+; Function calls
+(call_expression
+  function: (identifier) @function)
+
+; Method calls
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @function.method))

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -201,6 +201,7 @@ impl Editor {
             KeyCode::Char('r') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
                 if self.is_modified() {
                     self.buffer.reset_buffer();
+                    self.update_syntax_tree();
                 }
             }
             KeyCode::Char('s') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -218,9 +219,11 @@ impl Editor {
             }
             KeyCode::Char(ch) => {
                 self.buffer.insert_char(ch);
+                self.update_syntax_tree();
             }
             KeyCode::Backspace => {
                 self.buffer.delete_char();
+                self.update_syntax_tree();
             }
             KeyCode::Left => {
                 self.buffer.move_cursor_left();
@@ -236,6 +239,7 @@ impl Editor {
             }
             KeyCode::Enter => {
                 self.buffer.insert_char('\n');
+                self.update_syntax_tree();
             }
             _ => {}
         }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,12 +1,14 @@
 use fs::read_to_string;
 use crate::text_buffer::TextBuffer;
+use crate::syntax::{SyntaxHighlighter, HighlightType};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use crossterm::style::Print;
+use crossterm::style::{Print, ResetColor, SetStyle};
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode};
 use crossterm::{cursor, event, execute, terminal, terminal::enable_raw_mode};
 use std::{fs, io};
 use std::io::{Write, stdout};
 use std::path::PathBuf;
+use tree_sitter::Tree;
 
 pub struct Editor {
     buffer: TextBuffer,
@@ -14,6 +16,8 @@ pub struct Editor {
     viewport_size: usize,
     scroll_offset: usize,
     status_message: String,
+    syntax_highlighter: SyntaxHighlighter,
+    syntax_tree: Option<Tree>,
 }
 
 impl Editor {
@@ -24,28 +28,42 @@ impl Editor {
             viewport_size: 0,
             scroll_offset: 0,
             status_message: "Rust Text Editor".to_string(),
+            syntax_highlighter: SyntaxHighlighter::new(),
+            syntax_tree: None,
         }
     }
 
     pub fn with_content(content: String) -> Self {
-        Self {
+        let mut editor = Self{
             buffer: TextBuffer::from_string(content),
             current_file: None,
             scroll_offset: 0,
             viewport_size: 0,
             status_message: "Rust Text Editor".to_string(),
-        }
+            syntax_highlighter: SyntaxHighlighter::new(),
+            syntax_tree: None,
+        };
+        editor.update_syntax_tree();
+        editor
     }
 
     pub fn open_file(path: PathBuf) -> io::Result<Self> {
         let content = read_to_string(&path)?;
-        Ok(Self {
+        let mut editor = Self {
             buffer: TextBuffer::from_string(content),
             current_file: Some(path.clone()),
             scroll_offset: 0,
             viewport_size: 0,
             status_message: format!("Opened: {}", path.display()),
-        })
+            syntax_highlighter: SyntaxHighlighter::new(),
+            syntax_tree: None,
+        };
+
+        if let Err(e) = editor.syntax_highlighter.set_language_from_path(&path) {
+            editor.status_message = format!("Warning: Could not set syntax highlighting: {}", e)
+        }
+        editor.update_syntax_tree();
+        Ok(editor)
     }
 
     pub fn save_file(&mut self) -> io::Result<()> {
@@ -127,7 +145,7 @@ impl Editor {
             if buffer_line < total_lines {
                 let line = buffer_contents.line(buffer_line);
                 execute!(stdout(), terminal::Clear(terminal::ClearType::CurrentLine))?;
-                execute!(stdout(), Print(line))?;
+                self.render_line_with_highlighting(buffer_line);
             } else {
                 execute!(stdout(), terminal::Clear(terminal::ClearType::CurrentLine))?;
                 execute!(stdout(), Print("~"))?;
@@ -239,5 +257,52 @@ impl Editor {
 
     fn is_modified(&self) -> bool {
         self.buffer.is_modified()
+    }
+
+    fn update_syntax_tree(&mut self) {
+        let content = self.buffer.get_content();
+        self.syntax_tree = self.syntax_highlighter.parse(&content);
+    }
+
+    fn render_line_with_highlighting(&self, line_idx: usize) -> io::Result<()> {
+        let buffer_contents = self.buffer.get_content_rope();
+        let line = buffer_contents.line(line_idx);
+        let line_str = line.to_string();
+
+        let highlights = if let Some(tree) = &self.syntax_tree {
+            self.syntax_highlighter.highlight_line(buffer_contents, line_idx, tree)
+        } else {
+            Vec::new()
+        };
+
+        if highlights.is_empty() {
+            execute!(stdout(), Print(&line_str))?;
+            return Ok(());
+        }
+
+        let mut current_pos = 0;
+        let line_chars: Vec<char> = line_str.chars().collect();
+
+        for (start, end, highlight_type) in highlights {
+            if current_pos < start {
+                let before_text: String = line_chars[current_pos..start].iter().collect();
+                execute!(stdout(), ResetColor, Print(before_text))?;
+            }
+
+            if start < end && end <= line_chars.len() {
+                let highlighted_text: String = line_chars[start..end].iter().collect();
+                let style = highlight_type.to_style();
+                execute!(stdout(), SetStyle(style), Print(highlighted_text), ResetColor)?;
+            }
+
+            current_pos = end;
+        }
+
+        if current_pos < line_chars.len() {
+            let remaining_text: String = line_chars[current_pos..].iter().collect();
+            execute!(stdout(), Print(remaining_text))?;
+        }
+
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 mod editor;
 mod text_buffer;
+mod syntax;
 
 fn main() -> io::Result<()> {
     let args: Vec<String> = std::env::args().collect();

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,0 +1,139 @@
+use ropey::Rope;
+use std::path::Path;
+use crossterm::style::{Color, ContentStyle, Stylize};
+use tree_sitter::{Language, Parser, Query, QueryCursor, StreamingIterator, Tree};
+pub enum HighlightType {
+    Keyword,
+    String,
+    Comment,
+    Number,
+    Function,
+    FunctionMethod,
+}
+
+impl HighlightType {
+    pub fn to_style(self) -> ContentStyle {
+        match self {
+            HighlightType::Keyword => ContentStyle::new().with(Color::Blue),
+            HighlightType::Comment => ContentStyle::new().with(Color::Green),
+            HighlightType::String => ContentStyle::new().with(Color::Red),
+            HighlightType::Number => ContentStyle::new().with(Color::Yellow),
+            HighlightType::Function => ContentStyle::new().with(Color::DarkCyan),
+            HighlightType::FunctionMethod => ContentStyle::new().with(Color::Blue),
+        }
+    }
+}
+pub struct SyntaxHighlighter {
+    parser: Parser,
+    current_language: Option<Language>,
+    query: Option<Query>,
+    highlight_names: Vec<String>,
+}
+
+impl SyntaxHighlighter {
+    pub fn new() -> Self {
+        Self {
+            parser: Parser::new(),
+            current_language: None,
+            query: None,
+            highlight_names: Vec::new(),
+        }
+    }
+
+    pub fn set_language_from_path(
+        &mut self,
+        path: &Path,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Get the extension, map it to string, or default to "".
+        let extension = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+        // Map extension to a specific language, and a set of tree-sitter-queries.
+        let (language, query_source) = match extension {
+            "rs" => (
+                tree_sitter_rust::LANGUAGE.into(),
+                include_str!("../queries/rust.scm"),
+            ),
+            _ => return Ok(()), // No highlighting for unknown files.
+        };
+
+        self.parser.set_language(&language)?;
+        let query = Query::new(&language, query_source)?;
+        self.highlight_names = query
+            .capture_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        self.query = Some(query);
+
+        self.current_language = Some(language);
+
+        Ok(())
+    }
+
+    pub fn highlight_line(
+        &self,
+        rope: &Rope,
+        line_idx: usize,
+        tree: &Tree,
+    ) -> Vec<(usize, usize, HighlightType)> {
+        // If we have no query, return empty highlights
+        let Some(query) = &self.query else {
+            return Vec::new();
+        };
+
+        // Get byte offset for line start, and line end. If end of file, return number of bytes in file as end.
+        let line_start_byte = rope.line_to_byte(line_idx);
+        let line_end_byte = if line_idx + 1 < rope.len_lines() {
+            rope.line_to_byte(line_idx + 1)
+        } else {
+            rope.len_bytes()
+        };
+
+        let mut cursor = QueryCursor::new();
+        let mut highlights = Vec::new();
+
+        let line_start_char = rope.byte_to_char(line_start_byte);
+        let text_bytes = rope.to_string().into_bytes();
+
+        cursor.set_byte_range(line_start_byte..line_end_byte);
+
+        let mut matches = cursor.matches(query, tree.root_node(), text_bytes.as_slice());
+
+        while let Some(match_) = matches.next() {
+            for capture in match_.captures {
+                let start_byte = capture.node.start_byte();
+                let end_byte = capture.node.end_byte();
+
+                // Skip captures outside our line
+                if end_byte <= line_start_byte || start_byte >= line_end_byte {
+                    continue;
+                }
+
+                let capture_name = &self.highlight_names[capture.index as usize];
+                let highlight_type = match capture_name.as_str() {
+                    "keyword" => HighlightType::Keyword,
+                    "string" => HighlightType::String,
+                    "comment" => HighlightType::Comment,
+                    "number" => HighlightType::Number,
+                    "function" => HighlightType::Function,
+                    "function.method" => HighlightType::FunctionMethod,
+                    &_ => todo!(),
+                };
+
+                // Convert byte positions to character positions relative to line start
+                let start_char = rope.byte_to_char(start_byte);
+                let end_char = rope.byte_to_char(end_byte);
+
+                let relative_start = start_char - line_start_char;
+                let relative_end = end_char - line_start_char;
+
+                highlights.push((relative_start, relative_end, highlight_type));
+            }
+        }
+        highlights.sort_by_key(|&(start, _, _) | start);
+        highlights
+    }
+
+    pub fn parse(&mut self, text: &str) -> Option<Tree> {
+        self.parser.parse(text, None)
+    }
+}


### PR DESCRIPTION
Add tree-sitter syntax highlighting support

Implements syntax highlighting for Rust files using tree-sitter parser with keyword, string, comment, number, and function highlighting. Updates syntax tree on every text      
  modification.
  
Future improvement is not parsing the entire syntax tree for every change. It needs to be incremental. 