### PR TITLE
feat(server): Add a server for handling buffers, clients, and events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,10 +33,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -121,6 +163,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,10 +197,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -183,6 +264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,9 +280,24 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking_lot"
@@ -218,6 +323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +345,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -290,9 +407,18 @@ dependencies = [
  "cc",
  "crossterm",
  "ropey",
+ "serde",
+ "tokio",
  "tree-sitter",
  "tree-sitter-rust",
+ "uuid",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustix"
@@ -306,6 +432,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -389,10 +521,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "str_indices"
@@ -415,6 +563,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "slab",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -460,10 +639,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -486,6 +743,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -632,3 +898,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +501,7 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "crossterm",
+ "futures",
  "ropey",
  "serde",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,7 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.46.0", features = ["full"] }
 tree-sitter = "0.25.6"
 tree-sitter-rust = "0.24.0"
-uuid = { version = "1.17.0", features = ["v4"] }
+uuid = { version = "1.17.0", features = ["serde", "v4"] }
 
 [build-dependencies]
 cc = "1.2.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,11 @@ edition = "2024"
 [dependencies]
 crossterm = "0.29.0"
 ropey = "1.6.1"
+serde = { version = "1.0.219", features = ["derive"] }
+tokio = { version = "1.46.0", features = ["full"] }
 tree-sitter = "0.25.6"
 tree-sitter-rust = "0.24.0"
+uuid = { version = "1.17.0", features = ["v4"] }
 
 [build-dependencies]
 cc = "1.2.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 crossterm = "0.29.0"
+futures = "0.3.31"
 ropey = "1.6.1"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.46.0", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod server;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
+pub mod editor;
+pub mod text_buffer;
+pub mod syntax;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 mod editor;
 mod text_buffer;
 mod syntax;
+mod server;
 
 fn main() -> io::Result<()> {
     let args: Vec<String> = std::env::args().collect();

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -1,0 +1,1 @@
+pub struct Client {}

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -1,1 +1,5 @@
-pub struct Client {}
+use crate::server::events::EditorEvent;
+
+pub struct Client {
+    editor_events: Vec<EditorEvent>
+}

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -1,5 +1,16 @@
-use crate::server::events::EditorEvent;
+use std::collections::HashSet;
+use crate::server::events::{BufferId, EditorEvent};
 
 pub struct Client {
-    editor_events: Vec<EditorEvent>
+    editor_events: Vec<EditorEvent>,
+    subscribed_buffers: HashSet<BufferId>
+}
+
+impl Client {
+    pub(crate) fn new() -> Self{
+        Self {
+            editor_events: Vec::new(),
+            subscribed_buffers: HashSet::new()
+        }
+    }
 }

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -13,4 +13,26 @@ impl Client {
             subscribed_buffers: HashSet::new()
         }
     }
+
+    pub fn is_subscribed_to_buffer(&self, buffer_id: BufferId) -> bool {
+        self.subscribed_buffers.contains(&buffer_id)
+    }
+    pub fn subscribe_to_buffer(&mut self, buffer_id: BufferId) {
+        self.subscribed_buffers.insert(buffer_id);
+    }
+
+    pub fn unsubscribe_from_buffer(&mut self, buffer_id: BufferId) {
+        self.subscribed_buffers.remove(&buffer_id);
+    }
+
+    pub fn get_event_queue(&mut self) -> Vec<EditorEvent> {
+        // Clear the vector and return the contents
+        self.editor_events.drain(..).collect()
+    }
+
+    pub fn push_to_event_queue(&mut self, event: EditorEvent) {
+        self.editor_events.push(event);
+    }
+
+
 }

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -62,7 +62,7 @@ impl EditorServer {
         }
     }
     pub fn buffer_count(&self) -> usize {
-        todo!()
+        self.buffer_count
     }
     pub async fn create_buffer(&mut self, client_id: ClientId, content: Option<String>) -> ServerResult<BufferId> {
         let buffer = match content {
@@ -73,13 +73,13 @@ impl EditorServer {
                 TextBuffer::from_string(content)
             }
         };
-        
+
         let buffer_id = BufferId::new();
         self.buffers.insert(buffer_id, buffer);
         self.buffer_count += 1;
-        
+
         Ok(buffer_id)
-        
+
     }
 
     pub fn is_client_connected(&self, client_id: ClientId) -> bool {

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -7,6 +7,7 @@ use crate::server::events::ServerError::BufferNotFound;
 pub struct EditorServer {
     clients: HashMap<ClientId, Client>,
     buffers: HashMap<BufferId, TextBuffer>,
+    buffer_owners: HashMap<BufferId, ClientId>, // One client owner per buffer
 }
 
 impl EditorServer {
@@ -14,6 +15,7 @@ impl EditorServer {
         Self {
             clients: HashMap::new(),
             buffers: HashMap::new(),
+            buffer_owners: HashMap::new(),
         }
     }
     pub async fn set_edit_mode(&self, buffer_id: BufferId, mode: EditMode) -> ServerResult<()> {
@@ -114,6 +116,14 @@ impl EditorServer {
         client_id: ClientId,
         content: Option<String>,
     ) -> ServerResult<BufferId> {
+        let client = match self.clients.get(&client_id) {
+            None => {
+                return Err(BufferNotFound)
+
+            },
+            Some(client) => client
+        };
+
         let buffer = match content {
             None => TextBuffer::new(),
             Some(content) => TextBuffer::from_string(content),
@@ -121,6 +131,7 @@ impl EditorServer {
 
         let buffer_id = BufferId::new();
         self.buffers.insert(buffer_id, buffer);
+        self.buffer_owners.insert(buffer_id, client_id);
 
         Ok(buffer_id)
     }
@@ -132,7 +143,20 @@ impl EditorServer {
     pub async fn disconnect_client(&mut self, client_id: ClientId) -> ServerResult<()> {
         match self.clients.remove(&client_id) {
             None => Err(ServerError::ClientNotFound),
-            Some(_) => Ok(()),
+            Some(_) => {
+                let buffers_owned_by_client: Vec<BufferId> = self.buffer_owners
+                    .iter()
+                    .filter(|(_, owner) | **owner == client_id)
+                    .map(|(&buffer_id, _)|buffer_id)
+                    .collect();
+
+                for buffer_id in buffers_owned_by_client {
+                    self.buffers.remove(&buffer_id);
+                    self.buffer_owners.remove(&buffer_id);
+                }
+
+                Ok(())
+            },
         }
     }
 

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -1,9 +1,19 @@
-use crate::server::events::{BufferId, ClientId, EditMode, EditorEvent, ServerResult};
+use std::collections::HashMap;
+use crate::server::client::Client;
+use crate::server::events::{BufferId, ClientId, EditMode, EditorEvent, ServerError, ServerResult};
+use crate::text_buffer::TextBuffer;
 
 pub struct EditorServer {
+    clients: HashMap<ClientId, Client>,
+    client_count: usize,
+    buffers: HashMap<BufferId, TextBuffer>,
+    buffer_count: usize,
 }
 
 impl EditorServer {
+    pub async fn new() -> Self {
+        Self { clients: HashMap::new(), client_count: 0, buffers: HashMap::new(), buffer_count: 0 }
+    }
     pub async fn set_edit_mode(&self, buffer_id: BufferId, mode: EditMode) -> ServerResult<()> {
         todo!()
     }
@@ -16,7 +26,7 @@ impl EditorServer {
         todo!()
     }
 
-    pub async fn subscribe_to_buffer(&self, client_id: ClientId, buffer_id: BufferId) -> ServerResult<()>{
+    pub async fn subscribe_to_buffer(&self, client_id: ClientId, buffer_id: BufferId) -> ServerResult<()> {
         todo!()
     }
 
@@ -42,20 +52,41 @@ impl EditorServer {
     }
 
     pub async fn get_buffer_content(&self, buffer_id: BufferId) -> ServerResult<String> {
-        todo!()
+        match self.buffers.get(&buffer_id) {
+            None => {
+                Err(ServerError::BufferNotFound)
+            }
+            Some(buffer) => {
+                Ok(buffer.get_content())
+            }
+        }
     }
     pub fn buffer_count(&self) -> usize {
         todo!()
     }
-    pub async fn create_buffer(&self, client_id: ClientId, content: Option<String>) -> ServerResult<BufferId> {
-        todo!()
+    pub async fn create_buffer(&mut self, client_id: ClientId, content: Option<String>) -> ServerResult<BufferId> {
+        let buffer = match content {
+            None => {
+                TextBuffer::new()
+            }
+            Some(content) => {
+                TextBuffer::from_string(content)
+            }
+        };
+        
+        let buffer_id = BufferId::new();
+        self.buffers.insert(buffer_id, buffer);
+        self.buffer_count += 1;
+        
+        Ok(buffer_id)
+        
     }
 
     pub fn is_client_connected(&self, client_id: ClientId) -> bool {
         todo!()
     }
 
-    pub async fn disconnect_client(&self, client_id: ClientId) -> ServerResult<()>{
+    pub async fn disconnect_client(&self, client_id: ClientId) -> ServerResult<()> {
         todo!()
     }
 
@@ -63,10 +94,12 @@ impl EditorServer {
         todo!()
     }
 
-    pub async fn new() -> Self {
-        Self {}
-    }
-    pub async fn connect_client(&self) -> ServerResult<ClientId> {
-        todo!()
+
+    pub async fn connect_client(&mut self) -> ServerResult<ClientId> {
+        let client_id = ClientId::new();
+        let client = Client {};
+
+        self.clients.insert(client_id, client);
+        Ok(ClientId::new())
     }
 }

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -1,0 +1,72 @@
+use crate::server::events::{ClientId, EditMode, ServerResult};
+
+pub struct EditorServer {
+}
+
+impl EditorServer {
+    pub async fn set_edit_mode(&self, p0: _, p1: _) {
+        todo!()
+    }
+
+    pub async fn get_edit_mode(&self, p0: _) -> EditMode {
+        todo!()
+    }
+
+    pub async fn get_client_events(&self, p0: _) {
+        todo!()
+    }
+
+    pub async fn subscribe_to_buffer(&self, p0: _, p1: _) {
+        todo!()
+    }
+
+    pub async fn move_cursor_left(&self, p0: _) {
+        todo!()
+    }
+    pub async fn move_cursor_right(&self, p0: _) {
+        todo!()
+    }
+    pub async fn get_cursor_position(&self, p0: _) -> usize {
+        todo!()
+    }
+
+    pub async fn set_cursor_position(&self, p0: _, p1: i32) {
+        todo!()
+    }
+
+    pub async fn delete_char(&self, p0: _, p1: i32) {
+        todo!()
+    }
+    pub async fn insert_char(&self, p0: _, p1: i32, p2: char) {
+        todo!()
+    }
+
+    pub async fn get_buffer_content(&self, p0: _) {
+        todo!()
+    }
+    pub fn buffer_count(&self) -> usize {
+        todo!()
+    }
+    pub async fn create_buffer(&self, p0: _, p1: Option<_>) {
+        todo!()
+    }
+
+    pub fn is_client_connected(&self, p0: _) -> bool {
+        todo!()
+    }
+
+    pub async fn disconnect_client(&self, client_id: ClientId) {
+        todo!()
+    }
+
+    pub fn client_count(&self) -> usize {
+        todo!()
+    }
+
+    pub async fn new() -> Self {
+        Self {}
+    }
+    pub async fn connect_client(&self) -> ServerResult<ClientId> {
+        todo!()
+    }
+}

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -1,8 +1,10 @@
 use crate::server::client::Client;
-use crate::server::events::{BufferId, ClientId, EditMode, EditorEvent, ServerError, ServerResult};
+use crate::server::events::ServerError::{BufferNotFound, ClientNotFound};
+use crate::server::events::{
+    BufferId, ClientId, EditMode, EditorEvent, ServerError, ServerResult, TextChange,
+};
 use crate::text_buffer::TextBuffer;
 use std::collections::HashMap;
-use crate::server::events::ServerError::BufferNotFound;
 
 pub struct EditorServer {
     clients: HashMap<ClientId, Client>,
@@ -21,31 +23,71 @@ impl EditorServer {
     pub async fn set_edit_mode(&mut self, buffer_id: BufferId, mode: EditMode) -> ServerResult<()> {
         match self.buffers.get_mut(&buffer_id) {
             Some(buffer) => {
-                Ok(buffer.set_edit_mode(mode))
-            }
-            _ => Err(BufferNotFound)
+                buffer.set_edit_mode(mode.clone());
+
+                let event = EditorEvent::ModeChanged {
+                    buffer_id,
+                    mode,
+                };
+                self.broadcast_event_to_buffer(buffer_id, event).await;
+                Ok(())
+            },
+
+            _ => Err(BufferNotFound),
         }
     }
 
     pub async fn get_edit_mode(&self, buffer_id: BufferId) -> ServerResult<EditMode> {
         match self.buffers.get(&buffer_id) {
-            Some(buffer) => {
-                Ok(buffer.get_edit_mode())
-            }
-            _ => Err(BufferNotFound)
+            Some(buffer) => Ok(buffer.get_edit_mode()),
+            _ => Err(BufferNotFound),
         }
     }
 
-    pub async fn get_client_events(&self, client_id: ClientId) -> ServerResult<Vec<EditorEvent>> {
-        todo!()
+    pub async fn get_client_events(
+        &mut self,
+        client_id: ClientId,
+    ) -> ServerResult<Vec<EditorEvent>> {
+        let client = match self.clients.get_mut(&client_id) {
+            None => return Err(ClientNotFound),
+            Some(client) => client,
+        };
+
+        Ok(client.get_event_queue())
     }
 
     pub async fn subscribe_to_buffer(
-        &self,
+        &mut self,
         client_id: ClientId,
         buffer_id: BufferId,
     ) -> ServerResult<()> {
-        todo!()
+        let client = match self.clients.get_mut(&client_id) {
+            None => return Err(ClientNotFound),
+            Some(client) => client,
+        };
+
+        match self.buffers.get_mut(&buffer_id) {
+            None => return Err(BufferNotFound),
+            _ => {}
+        };
+
+        client.subscribe_to_buffer(buffer_id);
+        Ok(())
+    }
+
+    pub async fn broadcast_event_to_buffer(
+        &mut self,
+        buffer_id: BufferId,
+        event: EditorEvent,
+    ) -> ServerResult<()> {
+
+        for (client_id, client) in self.clients.iter_mut() {
+            if client.is_subscribed_to_buffer(buffer_id) {
+                client.push_to_event_queue(event.clone())
+            }
+        }
+
+        Ok(())
     }
 
     pub async fn move_cursor_left(&mut self, buffer_id: BufferId) -> ServerResult<()> {
@@ -64,13 +106,12 @@ impl EditorServer {
                 buffer.move_cursor_right();
                 Ok(())
             }
-        }    }
+        }
+    }
     pub async fn get_cursor_position(&self, buffer_id: BufferId) -> ServerResult<usize> {
         match self.buffers.get(&buffer_id) {
             None => Err(BufferNotFound),
-            Some(buffer) => {
-                Ok(buffer.get_cursor_position())
-            }
+            Some(buffer) => Ok(buffer.get_cursor_position()),
         }
     }
 
@@ -88,11 +129,26 @@ impl EditorServer {
         }
     }
 
-    pub async fn delete_char(&mut self, buffer_id: BufferId, position: i32) -> ServerResult<()> {
+    pub async fn delete_char(&mut self, buffer_id: BufferId, position: usize) -> ServerResult<()> {
         match self.buffers.get_mut(&buffer_id) {
             None => Err(ServerError::BufferNotFound),
             Some(buffer) => {
-                buffer.delete_char_at_position(position as usize);
+                let ch = buffer
+                    .delete_char_at_position(position)
+                    .map_err(|_| ServerError::InvalidOperation)?;
+
+                let change = TextChange {
+                    position,
+                    deleted_text: ch.to_string(),
+                    inserted_text: "".to_string(),
+                };
+
+                let event = EditorEvent::BufferChanged {
+                    buffer_id,
+                    changes: vec![change],
+                };
+
+                self.broadcast_event_to_buffer(buffer_id, event).await;
                 Ok(())
             }
         }
@@ -100,13 +156,27 @@ impl EditorServer {
     pub async fn insert_char(
         &mut self,
         buffer_id: BufferId,
-        position: i32,
+        position: usize,
         ch: char,
     ) -> ServerResult<()> {
         match self.buffers.get_mut(&buffer_id) {
             None => Err(ServerError::BufferNotFound),
             Some(buffer) => {
                 buffer.insert_char_at_position(position as usize, ch);
+
+                let change = TextChange {
+                    position,
+                    deleted_text: "".to_string(),
+                    inserted_text: ch.to_string(),
+                };
+
+                let event = EditorEvent::BufferChanged {
+                    buffer_id,
+                    changes: vec![change],
+                };
+
+                self.broadcast_event_to_buffer(buffer_id, event).await;
+
                 Ok(())
             }
         }
@@ -127,11 +197,8 @@ impl EditorServer {
         content: Option<String>,
     ) -> ServerResult<BufferId> {
         let client = match self.clients.get(&client_id) {
-            None => {
-                return Err(BufferNotFound)
-
-            },
-            Some(client) => client
+            None => return Err(BufferNotFound),
+            Some(client) => client,
         };
 
         let buffer = match content {
@@ -154,10 +221,11 @@ impl EditorServer {
         match self.clients.remove(&client_id) {
             None => Err(ServerError::ClientNotFound),
             Some(_) => {
-                let buffers_owned_by_client: Vec<BufferId> = self.buffer_owners
+                let buffers_owned_by_client: Vec<BufferId> = self
+                    .buffer_owners
                     .iter()
-                    .filter(|(_, owner) | **owner == client_id)
-                    .map(|(&buffer_id, _)|buffer_id)
+                    .filter(|(_, owner)| **owner == client_id)
+                    .map(|(&buffer_id, _)| buffer_id)
                     .collect();
 
                 for buffer_id in buffers_owned_by_client {
@@ -166,7 +234,7 @@ impl EditorServer {
                 }
 
                 Ok(())
-            },
+            }
         }
     }
 

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -2,6 +2,7 @@ use crate::server::client::Client;
 use crate::server::events::{BufferId, ClientId, EditMode, EditorEvent, ServerError, ServerResult};
 use crate::text_buffer::TextBuffer;
 use std::collections::HashMap;
+use crate::server::events::ServerError::BufferNotFound;
 
 pub struct EditorServer {
     clients: HashMap<ClientId, Client>,
@@ -35,22 +36,44 @@ impl EditorServer {
         todo!()
     }
 
-    pub async fn move_cursor_left(&self, buffer_id: BufferId) -> ServerResult<()> {
-        todo!()
+    pub async fn move_cursor_left(&mut self, buffer_id: BufferId) -> ServerResult<()> {
+        match self.buffers.get_mut(&buffer_id) {
+            None => Err(BufferNotFound),
+            Some(buffer) => {
+                buffer.move_cursor_left();
+                Ok(())
+            }
+        }
     }
-    pub async fn move_cursor_right(&self, buffer_id: BufferId) -> ServerResult<()> {
-        todo!()
-    }
+    pub async fn move_cursor_right(&mut self, buffer_id: BufferId) -> ServerResult<()> {
+        match self.buffers.get_mut(&buffer_id) {
+            None => Err(BufferNotFound),
+            Some(buffer) => {
+                buffer.move_cursor_right();
+                Ok(())
+            }
+        }    }
     pub async fn get_cursor_position(&self, buffer_id: BufferId) -> ServerResult<usize> {
-        todo!()
+        match self.buffers.get(&buffer_id) {
+            None => Err(BufferNotFound),
+            Some(buffer) => {
+                Ok(buffer.get_cursor_position())
+            }
+        }
     }
 
     pub async fn set_cursor_position(
-        &self,
+        &mut self,
         buffer_id: BufferId,
         position: i32,
     ) -> ServerResult<()> {
-        todo!()
+        match self.buffers.get_mut(&buffer_id) {
+            None => Err(BufferNotFound),
+            Some(buffer) => {
+                buffer.set_cursor_position(position as usize);
+                Ok(())
+            }
+        }
     }
 
     pub async fn delete_char(&mut self, buffer_id: BufferId, position: i32) -> ServerResult<()> {

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -18,12 +18,22 @@ impl EditorServer {
             buffer_owners: HashMap::new(),
         }
     }
-    pub async fn set_edit_mode(&self, buffer_id: BufferId, mode: EditMode) -> ServerResult<()> {
-        todo!()
+    pub async fn set_edit_mode(&mut self, buffer_id: BufferId, mode: EditMode) -> ServerResult<()> {
+        match self.buffers.get_mut(&buffer_id) {
+            Some(buffer) => {
+                Ok(buffer.set_edit_mode(mode))
+            }
+            _ => Err(BufferNotFound)
+        }
     }
 
     pub async fn get_edit_mode(&self, buffer_id: BufferId) -> ServerResult<EditMode> {
-        todo!()
+        match self.buffers.get(&buffer_id) {
+            Some(buffer) => {
+                Ok(buffer.get_edit_mode())
+            }
+            _ => Err(BufferNotFound)
+        }
     }
 
     pub async fn get_client_events(&self, client_id: ClientId) -> ServerResult<Vec<EditorEvent>> {

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -53,16 +53,28 @@ impl EditorServer {
         todo!()
     }
 
-    pub async fn delete_char(&self, buffer_id: BufferId, position: i32) -> ServerResult<()> {
-        todo!()
+    pub async fn delete_char(&mut self, buffer_id: BufferId, position: i32) -> ServerResult<()> {
+        match self.buffers.get_mut(&buffer_id) {
+            None => Err(ServerError::BufferNotFound),
+            Some(buffer) => {
+                buffer.delete_char_at_position(position as usize);
+                Ok(())
+            }
+        }
     }
     pub async fn insert_char(
-        &self,
+        &mut self,
         buffer_id: BufferId,
         position: i32,
         ch: char,
     ) -> ServerResult<()> {
-        todo!()
+        match self.buffers.get_mut(&buffer_id) {
+            None => Err(ServerError::BufferNotFound),
+            Some(buffer) => {
+                buffer.insert_char_at_position(position as usize, ch);
+                Ok(())
+            }
+        }
     }
 
     pub async fn get_buffer_content(&self, buffer_id: BufferId) -> ServerResult<String> {
@@ -91,15 +103,14 @@ impl EditorServer {
     }
 
     pub fn is_client_connected(&self, client_id: ClientId) -> bool {
-        if self.clients.contains_key(&client_id) {
-            true
-        } else {
-            false
-        }
+        self.clients.contains_key(&client_id)
     }
 
     pub async fn disconnect_client(&mut self, client_id: ClientId) -> ServerResult<()> {
-        todo!()
+        match self.clients.remove(&client_id) {
+            None => Err(ServerError::ClientNotFound),
+            Some(_) => Ok(()),
+        }
     }
 
     pub fn client_count(&self) -> usize {
@@ -111,6 +122,6 @@ impl EditorServer {
         let client = Client::new();
 
         self.clients.insert(client_id, client);
-        Ok(ClientId::new())
+        Ok(client_id)
     }
 }

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -5,14 +5,12 @@ use crate::text_buffer::TextBuffer;
 
 pub struct EditorServer {
     clients: HashMap<ClientId, Client>,
-    client_count: usize,
     buffers: HashMap<BufferId, TextBuffer>,
-    buffer_count: usize,
 }
 
 impl EditorServer {
     pub async fn new() -> Self {
-        Self { clients: HashMap::new(), client_count: 0, buffers: HashMap::new(), buffer_count: 0 }
+        Self { clients: HashMap::new(), buffers: HashMap::new() }
     }
     pub async fn set_edit_mode(&self, buffer_id: BufferId, mode: EditMode) -> ServerResult<()> {
         todo!()
@@ -62,7 +60,7 @@ impl EditorServer {
         }
     }
     pub fn buffer_count(&self) -> usize {
-        self.buffer_count
+        self.buffers.len()
     }
     pub async fn create_buffer(&mut self, client_id: ClientId, content: Option<String>) -> ServerResult<BufferId> {
         let buffer = match content {
@@ -76,7 +74,6 @@ impl EditorServer {
 
         let buffer_id = BufferId::new();
         self.buffers.insert(buffer_id, buffer);
-        self.buffer_count += 1;
 
         Ok(buffer_id)
 
@@ -86,8 +83,13 @@ impl EditorServer {
         todo!()
     }
 
-    pub async fn disconnect_client(&self, client_id: ClientId) -> ServerResult<()> {
-        todo!()
+    pub async fn disconnect_client(&mut self, client_id: ClientId) -> ServerResult<()> {
+        match self.clients.remove(&client_id) {
+            None => {}
+            Some(client) => {
+                
+            }
+        }
     }
 
     pub fn client_count(&self) -> usize {

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -1,61 +1,61 @@
-use crate::server::events::{ClientId, EditMode, ServerResult};
+use crate::server::events::{BufferId, ClientId, EditMode, EditorEvent, ServerResult};
 
 pub struct EditorServer {
 }
 
 impl EditorServer {
-    pub async fn set_edit_mode(&self, p0: _, p1: _) {
+    pub async fn set_edit_mode(&self, buffer_id: BufferId, mode: EditMode) -> ServerResult<()> {
         todo!()
     }
 
-    pub async fn get_edit_mode(&self, p0: _) -> EditMode {
+    pub async fn get_edit_mode(&self, buffer_id: BufferId) -> ServerResult<EditMode> {
         todo!()
     }
 
-    pub async fn get_client_events(&self, p0: _) {
+    pub async fn get_client_events(&self, client_id: ClientId) -> ServerResult<Vec<EditorEvent>> {
         todo!()
     }
 
-    pub async fn subscribe_to_buffer(&self, p0: _, p1: _) {
+    pub async fn subscribe_to_buffer(&self, client_id: ClientId, buffer_id: BufferId) -> ServerResult<()>{
         todo!()
     }
 
-    pub async fn move_cursor_left(&self, p0: _) {
+    pub async fn move_cursor_left(&self, buffer_id: BufferId) -> ServerResult<()> {
         todo!()
     }
-    pub async fn move_cursor_right(&self, p0: _) {
+    pub async fn move_cursor_right(&self, buffer_id: BufferId) -> ServerResult<()> {
         todo!()
     }
-    pub async fn get_cursor_position(&self, p0: _) -> usize {
-        todo!()
-    }
-
-    pub async fn set_cursor_position(&self, p0: _, p1: i32) {
+    pub async fn get_cursor_position(&self, buffer_id: BufferId) -> ServerResult<usize> {
         todo!()
     }
 
-    pub async fn delete_char(&self, p0: _, p1: i32) {
-        todo!()
-    }
-    pub async fn insert_char(&self, p0: _, p1: i32, p2: char) {
+    pub async fn set_cursor_position(&self, buffer_id: BufferId, position: i32) -> ServerResult<()> {
         todo!()
     }
 
-    pub async fn get_buffer_content(&self, p0: _) {
+    pub async fn delete_char(&self, buffer_id: BufferId, position: i32) -> ServerResult<()> {
+        todo!()
+    }
+    pub async fn insert_char(&self, buffer_id: BufferId, position: i32, ch: char) -> ServerResult<()> {
+        todo!()
+    }
+
+    pub async fn get_buffer_content(&self, buffer_id: BufferId) -> ServerResult<String> {
         todo!()
     }
     pub fn buffer_count(&self) -> usize {
         todo!()
     }
-    pub async fn create_buffer(&self, p0: _, p1: Option<_>) {
+    pub async fn create_buffer(&self, client_id: ClientId, content: Option<String>) -> ServerResult<BufferId> {
         todo!()
     }
 
-    pub fn is_client_connected(&self, p0: _) -> bool {
+    pub fn is_client_connected(&self, client_id: ClientId) -> bool {
         todo!()
     }
 
-    pub async fn disconnect_client(&self, client_id: ClientId) {
+    pub async fn disconnect_client(&self, client_id: ClientId) -> ServerResult<()>{
         todo!()
     }
 

--- a/src/server/editor_server.rs
+++ b/src/server/editor_server.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use crate::server::client::Client;
 use crate::server::events::{BufferId, ClientId, EditMode, EditorEvent, ServerError, ServerResult};
 use crate::text_buffer::TextBuffer;
+use std::collections::HashMap;
 
 pub struct EditorServer {
     clients: HashMap<ClientId, Client>,
@@ -10,7 +10,10 @@ pub struct EditorServer {
 
 impl EditorServer {
     pub async fn new() -> Self {
-        Self { clients: HashMap::new(), buffers: HashMap::new() }
+        Self {
+            clients: HashMap::new(),
+            buffers: HashMap::new(),
+        }
     }
     pub async fn set_edit_mode(&self, buffer_id: BufferId, mode: EditMode) -> ServerResult<()> {
         todo!()
@@ -24,7 +27,11 @@ impl EditorServer {
         todo!()
     }
 
-    pub async fn subscribe_to_buffer(&self, client_id: ClientId, buffer_id: BufferId) -> ServerResult<()> {
+    pub async fn subscribe_to_buffer(
+        &self,
+        client_id: ClientId,
+        buffer_id: BufferId,
+    ) -> ServerResult<()> {
         todo!()
     }
 
@@ -38,68 +45,70 @@ impl EditorServer {
         todo!()
     }
 
-    pub async fn set_cursor_position(&self, buffer_id: BufferId, position: i32) -> ServerResult<()> {
+    pub async fn set_cursor_position(
+        &self,
+        buffer_id: BufferId,
+        position: i32,
+    ) -> ServerResult<()> {
         todo!()
     }
 
     pub async fn delete_char(&self, buffer_id: BufferId, position: i32) -> ServerResult<()> {
         todo!()
     }
-    pub async fn insert_char(&self, buffer_id: BufferId, position: i32, ch: char) -> ServerResult<()> {
+    pub async fn insert_char(
+        &self,
+        buffer_id: BufferId,
+        position: i32,
+        ch: char,
+    ) -> ServerResult<()> {
         todo!()
     }
 
     pub async fn get_buffer_content(&self, buffer_id: BufferId) -> ServerResult<String> {
         match self.buffers.get(&buffer_id) {
-            None => {
-                Err(ServerError::BufferNotFound)
-            }
-            Some(buffer) => {
-                Ok(buffer.get_content())
-            }
+            None => Err(ServerError::BufferNotFound),
+            Some(buffer) => Ok(buffer.get_content()),
         }
     }
     pub fn buffer_count(&self) -> usize {
         self.buffers.len()
     }
-    pub async fn create_buffer(&mut self, client_id: ClientId, content: Option<String>) -> ServerResult<BufferId> {
+    pub async fn create_buffer(
+        &mut self,
+        client_id: ClientId,
+        content: Option<String>,
+    ) -> ServerResult<BufferId> {
         let buffer = match content {
-            None => {
-                TextBuffer::new()
-            }
-            Some(content) => {
-                TextBuffer::from_string(content)
-            }
+            None => TextBuffer::new(),
+            Some(content) => TextBuffer::from_string(content),
         };
 
         let buffer_id = BufferId::new();
         self.buffers.insert(buffer_id, buffer);
 
         Ok(buffer_id)
-
     }
 
     pub fn is_client_connected(&self, client_id: ClientId) -> bool {
-        todo!()
-    }
-
-    pub async fn disconnect_client(&mut self, client_id: ClientId) -> ServerResult<()> {
-        match self.clients.remove(&client_id) {
-            None => {}
-            Some(client) => {
-                
-            }
+        if self.clients.contains_key(&client_id) {
+            true
+        } else {
+            false
         }
     }
 
-    pub fn client_count(&self) -> usize {
+    pub async fn disconnect_client(&mut self, client_id: ClientId) -> ServerResult<()> {
         todo!()
     }
 
+    pub fn client_count(&self) -> usize {
+        self.clients.len()
+    }
 
     pub async fn connect_client(&mut self) -> ServerResult<ClientId> {
         let client_id = ClientId::new();
-        let client = Client {};
+        let client = Client::new();
 
         self.clients.insert(client_id, client);
         Ok(ClientId::new())

--- a/src/server/events.rs
+++ b/src/server/events.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Serialize, Deserialize, Deserializer};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/server/events.rs
+++ b/src/server/events.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ClientId(Uuid);
+
+impl ClientId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BufferId(Uuid);
+
+impl BufferId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum EditMode {
+    Normal,
+    Insert,
+    Visual,
+    Command,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EditorEvent {
+    BufferChanged {
+        buffer_id: BufferId,
+        changes: Vec<TextChange>,
+    },
+    CursorMoved {
+        buffer_id: BufferId,
+        position: usize,
+    },
+    ModeChanged {
+        buffer_id: BufferId,
+        mode: EditMode,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextChange {
+    pub position: usize,
+    pub deleted_text: String,
+    pub inserted_text: String,
+}
+
+#[derive(Debug)]
+pub enum ServerError {
+    ClientNotFound,
+    BufferNotFound,
+    InvalidOperation,
+    InternalError(String),
+}
+
+impl std::fmt::Display for ServerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ServerError::ClientNotFound => write!(f, "Client not found"),
+            ServerError::BufferNotFound => write!(f, "Buffer not found"),
+            ServerError::InvalidOperation => write!(f, "Invalid operation"),
+            ServerError::InternalError(msg) => write!(f, "Internal error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for ServerError {}
+
+pub type ServerResult<T> = Result<T, ServerError>;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,3 @@
+mod editor_server;
+mod client;
+mod events;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,3 @@
-mod editor_server;
-mod client;
-mod events;
+pub mod editor_server;
+pub mod client;
+pub mod events;

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -71,18 +71,19 @@ impl TextBuffer {
         }
     }
 
-    pub fn delete_char_at_position(&mut self, position: usize) -> Result<(), String> {
+    pub fn delete_char_at_position(&mut self, position: usize) -> Result<char, String> {
         if position >= self.content.len_chars() {
-            return Err("Attempting to delete char at position out of bounds".to_string());
+            return Err("Position out of bounds".to_string());
         }
 
+        let deleted_char = self.content.char(position);
         self.content.remove(position..position + 1);
 
-        // If we delete at cursor position or to the left, we keep the cursor where it is to the left.
         if position < self.cursor_position {
-            self.move_cursor_left();
+            self.cursor_position -= 1;
         }
-        Ok(())
+
+        Ok(deleted_char)
     }
     pub fn insert_char(&mut self, ch: char) {
         self.content.insert_char(self.cursor_position, ch);

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -1,6 +1,7 @@
 use ropey::Rope;
 use std::cmp::min;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use crate::server::events::EditMode;
 
 pub struct TextBuffer {
     content: Rope,
@@ -9,6 +10,7 @@ pub struct TextBuffer {
     original_cursor_position: usize,
     cursor_position: usize,
     content_hash: u64,
+    edit_mode: EditMode
 }
 
 impl TextBuffer {
@@ -22,6 +24,7 @@ impl TextBuffer {
             original_cursor_position: 0,
             cursor_position: 0,
             content_hash,
+            edit_mode: EditMode::Normal,
         }
     }
 
@@ -36,6 +39,7 @@ impl TextBuffer {
             original_content: content,
             original_content_hash: content_hash,
             content_hash,
+            edit_mode: EditMode::Normal,
         }
     }
 
@@ -191,6 +195,15 @@ impl TextBuffer {
         self.cursor_position = self.original_cursor_position;
         self.content_hash = Self::hash_rope(&self.content);
     }
+
+    pub fn get_edit_mode(&self) -> EditMode {
+        self.edit_mode.clone()
+    }
+
+    pub fn set_edit_mode(&mut self, mode: EditMode) {
+        self.edit_mode = mode;
+    }
+
 }
 
 #[cfg(test)]

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -1,6 +1,6 @@
+use ropey::Rope;
 use std::cmp::min;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use ropey::Rope;
 
 pub struct TextBuffer {
     content: Rope,
@@ -50,6 +50,36 @@ impl TextBuffer {
         self.cursor_position
     }
 
+    pub fn set_cursor_position(&mut self, position: usize) -> Result<(), String> {
+        if position > self.content.len_chars() {
+            Err("Attempting to set cursor position out of bounds".to_string())
+        } else {
+            self.cursor_position = position;
+            Ok(())
+        }
+    }
+    pub fn insert_char_at_position(&mut self, position: usize, ch: char) {
+        self.content.insert_char(position, ch);
+
+        // If we insert at cursor position or to the left, we move the cursor position to the right
+        if position <= self.cursor_position {
+            self.move_cursor_right();
+        }
+    }
+
+    pub fn delete_char_at_position(&mut self, position: usize) -> Result<(), String> {
+        if position >= self.content.len_chars() {
+            return Err("Attempting to delete char at position out of bounds".to_string());
+        }
+
+        self.content.remove(position..position + 1);
+
+        // If we delete at cursor position or to the left, we keep the cursor where it is to the left.
+        if position < self.cursor_position {
+            self.move_cursor_left();
+        }
+        Ok(())
+    }
     pub fn insert_char(&mut self, ch: char) {
         self.content.insert_char(self.cursor_position, ch);
         self.cursor_position += 1;
@@ -83,7 +113,7 @@ impl TextBuffer {
             let col_in_line = self.cursor_position - current_line_start;
 
             let prev_line_start = self.content.line_to_char(line_idx - 1);
-            let prev_line_len = self.content.line(line_idx-1).len_chars();
+            let prev_line_len = self.content.line(line_idx - 1).len_chars();
 
             self.cursor_position = prev_line_start + min(col_in_line, prev_line_len);
         }
@@ -100,7 +130,7 @@ impl TextBuffer {
             let col_in_line = self.cursor_position - current_line_start;
 
             let prev_line_start = self.content.line_to_char(line_idx + 1);
-            let prev_line_len = self.content.line(line_idx+1).len_chars();
+            let prev_line_len = self.content.line(line_idx + 1).len_chars();
 
             self.cursor_position = prev_line_start + min(col_in_line, prev_line_len);
         }
@@ -364,5 +394,137 @@ mod tests {
 
         assert!(!buffer.is_modified());
         assert_eq!(buffer.get_content(), "hello");
+    }
+
+    #[test]
+    fn test_set_cursor_position_valid() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+
+        // Should succeed for valid positions
+        assert!(buffer.set_cursor_position(0).is_ok());
+        assert_eq!(buffer.get_cursor_position(), 0);
+
+        assert!(buffer.set_cursor_position(3).is_ok());
+        assert_eq!(buffer.get_cursor_position(), 3);
+
+        assert!(buffer.set_cursor_position(5).is_ok()); // End of string
+        assert_eq!(buffer.get_cursor_position(), 5);
+    }
+
+    #[test]
+    fn test_set_cursor_position_invalid() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+
+        // Should fail for out of bounds
+        assert!(buffer.set_cursor_position(6).is_err());
+
+        // Cursor should remain unchanged after failed set
+        let original_pos = buffer.get_cursor_position();
+        let _ = buffer.set_cursor_position(10);
+        assert_eq!(buffer.get_cursor_position(), original_pos);
+    }
+
+    #[test]
+    fn test_insert_char_at_position_beginning() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        buffer.set_cursor_position(3).unwrap(); // Cursor at 'l'
+
+        buffer.insert_char_at_position(0, 'X');
+
+        assert_eq!(buffer.get_content(), "Xhello");
+        assert_eq!(buffer.get_cursor_position(), 4); // Cursor moved right
+    }
+
+    #[test]
+    fn test_insert_char_at_position_middle() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        buffer.set_cursor_position(1).unwrap(); // Cursor at 'e'
+
+        buffer.insert_char_at_position(3, 'X'); // Insert after cursor
+
+        assert_eq!(buffer.get_content(), "helXlo");
+        assert_eq!(buffer.get_cursor_position(), 1); // Cursor unchanged
+    }
+
+    #[test]
+    fn test_insert_char_at_position_before_cursor() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        buffer.set_cursor_position(3).unwrap(); // Cursor at first 'l'
+
+        buffer.insert_char_at_position(2, 'X'); // Insert before cursor
+
+        assert_eq!(buffer.get_content(), "heXllo");
+        assert_eq!(buffer.get_cursor_position(), 4); // Cursor moved right
+    }
+
+    #[test]
+    fn test_insert_char_at_position_at_cursor() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        buffer.set_cursor_position(2).unwrap(); // Cursor at first 'l'
+
+        buffer.insert_char_at_position(2, 'X'); // Insert exactly at cursor
+
+        assert_eq!(buffer.get_content(), "heXllo");
+        // What should happen to cursor when inserting AT cursor position?
+        // Your current logic: position <= cursor_position, so cursor moves right
+        assert_eq!(buffer.get_cursor_position(), 3);
+    }
+
+    #[test]
+    fn test_delete_char_at_position_before_cursor() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        buffer.set_cursor_position(3).unwrap(); // Cursor at first 'l'
+
+        buffer.delete_char_at_position(1); // Delete 'e'
+
+        assert_eq!(buffer.get_content(), "hllo");
+        assert_eq!(buffer.get_cursor_position(), 2); // Cursor moved left
+    }
+
+    #[test]
+    fn test_delete_char_at_position_after_cursor() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        buffer.set_cursor_position(1).unwrap(); // Cursor at 'e'
+
+        buffer.delete_char_at_position(3); // Delete first 'l'
+
+        assert_eq!(buffer.get_content(), "helo");
+        assert_eq!(buffer.get_cursor_position(), 1); // Cursor unchanged
+    }
+
+    #[test]
+    fn test_delete_char_at_position_at_cursor() {
+        let mut buffer = TextBuffer::from_string("hello".to_string());
+        buffer.set_cursor_position(2).unwrap(); // Cursor at first 'l'
+
+        buffer.delete_char_at_position(2); // Delete character AT cursor
+
+        assert_eq!(buffer.get_content(), "helo");
+        // What should cursor position be after deleting AT cursor?
+        // Your current logic: position < cursor_position (false), so no change
+        assert_eq!(buffer.get_cursor_position(), 2);
+    }
+
+
+    #[test]
+    fn test_delete_char_out_of_bounds() {
+        let mut buffer = TextBuffer::from_string("hi".to_string());
+
+        // Should this panic, or gracefully handle?
+        buffer.delete_char_at_position(5);
+    }
+
+    #[test]
+    fn test_position_methods_with_unicode() {
+        let mut buffer = TextBuffer::from_string("🦀é".to_string());
+        buffer.set_cursor_position(1).unwrap(); // After crab emoji
+
+        buffer.insert_char_at_position(0, 'A');
+        assert_eq!(buffer.get_content(), "A🦀é");
+        assert_eq!(buffer.get_cursor_position(), 2); // Cursor moved right
+
+        buffer.delete_char_at_position(0); // Delete 'A'
+        assert_eq!(buffer.get_content(), "🦀é");
+        assert_eq!(buffer.get_cursor_position(), 1); // Cursor moved left
     }
 }

--- a/tests/client_server_tests.rs
+++ b/tests/client_server_tests.rs
@@ -1,6 +1,7 @@
-use rust_text_editor::server::*;
+use rust_text_editor::server::editor_server::EditorServer;
 use tokio::time::{timeout, Duration};
 use std::collections::HashMap;
+use rust_text_editor::server::events::{BufferId, ClientId, EditMode, EditorEvent};
 
 #[tokio::test]
 async fn test_server_creation() {

--- a/tests/client_server_tests.rs
+++ b/tests/client_server_tests.rs
@@ -1,0 +1,222 @@
+use rust_text_editor::server::*;
+use tokio::time::{timeout, Duration};
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn test_server_creation() {
+    let server = EditorServer::new().await;
+    assert_eq!(server.buffer_count(), 0);
+    assert_eq!(server.client_count(), 0);
+}
+
+#[tokio::test]
+async fn test_client_connection() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+
+    assert_eq!(server.client_count(), 1);
+    assert!(server.is_client_connected(client_id));
+}
+
+#[tokio::test]
+async fn test_client_disconnection() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+
+    server.disconnect_client(client_id).await.unwrap();
+    assert_eq!(server.client_count(), 0);
+    assert!(!server.is_client_connected(client_id));
+}
+
+#[tokio::test]
+async fn test_buffer_creation() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+
+    let buffer_id = server.create_buffer(client_id, None).await.unwrap();
+    assert_eq!(server.buffer_count(), 1);
+
+    let content = server.get_buffer_content(buffer_id).await.unwrap();
+    assert_eq!(content, "");
+}
+
+#[tokio::test]
+async fn test_buffer_creation_with_content() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+
+    let initial_content = "Hello, World!";
+    let buffer_id = server.create_buffer(client_id, Some(initial_content.to_string())).await.unwrap();
+
+    let content = server.get_buffer_content(buffer_id).await.unwrap();
+    assert_eq!(content, initial_content);
+}
+
+#[tokio::test]
+async fn test_buffer_edit_operations() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+    let buffer_id = server.create_buffer(client_id, Some("abc".to_string())).await.unwrap();
+
+    // Insert character at position
+    server.insert_char(buffer_id, 1, 'X').await.unwrap();
+    let content = server.get_buffer_content(buffer_id).await.unwrap();
+    assert_eq!(content, "aXbc");
+
+    // Delete character
+    server.delete_char(buffer_id, 1).await.unwrap();
+    let content = server.get_buffer_content(buffer_id).await.unwrap();
+    assert_eq!(content, "abc");
+}
+
+#[tokio::test]
+async fn test_cursor_operations() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+    let buffer_id = server.create_buffer(client_id, Some("hello\nworld".to_string())).await.unwrap();
+
+    // Set cursor position
+    server.set_cursor_position(buffer_id, 3).await.unwrap();
+    let pos = server.get_cursor_position(buffer_id).await.unwrap();
+    assert_eq!(pos, 3);
+
+    // Move cursor operations
+    server.move_cursor_right(buffer_id).await.unwrap();
+    let pos = server.get_cursor_position(buffer_id).await.unwrap();
+    assert_eq!(pos, 4);
+
+    server.move_cursor_left(buffer_id).await.unwrap();
+    let pos = server.get_cursor_position(buffer_id).await.unwrap();
+    assert_eq!(pos, 3);
+}
+
+#[tokio::test]
+async fn test_event_broadcasting() {
+    let mut server = EditorServer::new().await;
+    let client1_id = server.connect_client().await.unwrap();
+    let client2_id = server.connect_client().await.unwrap();
+
+    let buffer_id = server.create_buffer(client1_id, None).await.unwrap();
+
+    // Subscribe both clients to buffer events
+    server.subscribe_to_buffer(client1_id, buffer_id).await.unwrap();
+    server.subscribe_to_buffer(client2_id, buffer_id).await.unwrap();
+
+    // Make a change that should trigger events
+    server.insert_char(buffer_id, 0, 'A').await.unwrap();
+
+    // Both clients should receive the event
+    let client1_events = server.get_client_events(client1_id).await.unwrap();
+    let client2_events = server.get_client_events(client2_id).await.unwrap();
+
+    assert!(!client1_events.is_empty());
+    assert!(!client2_events.is_empty());
+
+    // Check event content
+    if let EditorEvent::BufferChanged { buffer_id: event_buffer_id, .. } = &client1_events[0] {
+        assert_eq!(*event_buffer_id, buffer_id);
+    } else {
+        panic!("Expected BufferChanged event");
+    }
+}
+
+#[tokio::test]
+async fn test_modal_editing_states() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+    let buffer_id = server.create_buffer(client_id, None).await.unwrap();
+
+    // Default mode should be Normal
+    let mode = server.get_edit_mode(buffer_id).await.unwrap();
+    assert_eq!(mode, EditMode::Normal);
+
+    // Switch to Insert mode
+    server.set_edit_mode(buffer_id, EditMode::Insert).await.unwrap();
+    let mode = server.get_edit_mode(buffer_id).await.unwrap();
+    assert_eq!(mode, EditMode::Insert);
+
+    // Switch to Visual mode
+    server.set_edit_mode(buffer_id, EditMode::Visual).await.unwrap();
+    let mode = server.get_edit_mode(buffer_id).await.unwrap();
+    assert_eq!(mode, EditMode::Visual);
+}
+
+#[tokio::test]
+async fn test_mode_change_events() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+    let buffer_id = server.create_buffer(client_id, None).await.unwrap();
+
+    server.subscribe_to_buffer(client_id, buffer_id).await.unwrap();
+
+    server.set_edit_mode(buffer_id, EditMode::Insert).await.unwrap();
+
+    let events = server.get_client_events(client_id).await.unwrap();
+    let mode_events: Vec<_> = events.iter()
+        .filter_map(|e| match e {
+            EditorEvent::ModeChanged { mode, .. } => Some(mode),
+            _ => None
+        })
+        .collect();
+
+    assert!(!mode_events.is_empty());
+    assert_eq!(*mode_events[0], EditMode::Insert);
+}
+
+#[tokio::test]
+async fn test_concurrent_client_operations() {
+    let server = std::sync::Arc::new(tokio::sync::Mutex::new(EditorServer::new().await));
+
+    let handles: Vec<_> = (0..5).map(|i| {
+        let server_clone = server.clone();
+        tokio::spawn(async move {
+            let mut server_guard = server_clone.lock().await;
+            let client_id = server_guard.connect_client().await.unwrap();
+            let buffer_id = server_guard.create_buffer(client_id, Some(format!("Buffer {}", i))).await.unwrap();
+            (client_id, buffer_id)
+        })
+    }).collect();
+
+    let results: Vec<_> = futures::future::join_all(handles).await;
+
+    for result in results {
+        let (client_id, buffer_id) = result.unwrap();
+        let server_guard = server.lock().await;
+        assert!(server_guard.is_client_connected(client_id));
+        assert!(server_guard.get_buffer_content(buffer_id).await.is_ok());
+    }
+
+    let server_guard = server.lock().await;
+    assert_eq!(server_guard.client_count(), 5);
+    assert_eq!(server_guard.buffer_count(), 5);
+}
+
+#[tokio::test]
+async fn test_error_handling() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+
+    // Try to operate on non-existent buffer
+    let fake_buffer_id = BufferId::new();
+    assert!(server.get_buffer_content(fake_buffer_id).await.is_err());
+    assert!(server.insert_char(fake_buffer_id, 0, 'A').await.is_err());
+
+    // Try to operate with non-existent client
+    let fake_client_id = ClientId::new();
+    assert!(server.create_buffer(fake_client_id, None).await.is_err());
+}
+
+#[tokio::test]
+async fn test_buffer_cleanup_on_client_disconnect() {
+    let mut server = EditorServer::new().await;
+    let client_id = server.connect_client().await.unwrap();
+    let buffer_id = server.create_buffer(client_id, None).await.unwrap();
+
+    assert_eq!(server.buffer_count(), 1);
+
+    server.disconnect_client(client_id).await.unwrap();
+
+    // Buffer should be cleaned up when client disconnects
+    assert_eq!(server.buffer_count(), 0);
+    assert!(server.get_buffer_content(buffer_id).await.is_err());
+}


### PR DESCRIPTION
- **Add empty files**
- **Add tokio, uuid and serde as dependencies**
- **Add events.rs datastructures, and add tests in client_server_tests.rs**
- **Working on making tests compile.**
- **Tests compile now.**
- **Buffer creation implemented.**
- **Buffer count implemented.**
- **Fix buffer count to use hashmap internal count which is O(1), and add editor events to client.rs**
- **Add Client constructor**
- **Implement client count and is_client_connected**
- **Implement inserting and deleting chars in  text_buffer.rs**
- **Implemented insert and delete in char from server**
- **Implemented cursor navigation**
- **Buffers cleaned up when client disconnects.**
- **Add buffer edit_mode**
- **Add event subscription.**
